### PR TITLE
tools/install-manpages: improve echoing

### DIFF
--- a/tools/install-manpages
+++ b/tools/install-manpages
@@ -28,14 +28,19 @@ do
     basename=$(basename "$manpage")
     suffix=${basename#*.}
     locale=${suffix%.*}
-    [ "$locale" = "$suffix" ] && locale=
+    if [ "$locale" = "$suffix" ]
+    then
+       locale=
+    else
+       locale=${locale}/
+    fi
     section=${suffix#*.}
     basename=${basename%%.*}
     (
         PS4='$ '
         set -x
-        $INSTALL -d "$mandir/$locale/man$section"
-        $INSTALL -m 644 "$manpage" "$mandir/$locale/man$section/$basename.$section"
+        $INSTALL -d "$mandir/${locale}man$section"
+        $INSTALL -m 644 "$manpage" "$mandir/${locale}man$section/$basename.$section"
     )
 done
 

--- a/tools/install-manpages
+++ b/tools/install-manpages
@@ -28,7 +28,7 @@ do
     basename=$(basename "$manpage")
     suffix=${basename#*.}
     locale=${suffix%.*}
-    if [ "$locale" = "$suffix" ] && locale= || locale=$locale/
+    [ "$locale" = "$suffix" ] && locale= || locale=$locale/
     section=${suffix#*.}
     basename=${basename%%.*}
     (

--- a/tools/install-manpages
+++ b/tools/install-manpages
@@ -28,12 +28,7 @@ do
     basename=$(basename "$manpage")
     suffix=${basename#*.}
     locale=${suffix%.*}
-    if [ "$locale" = "$suffix" ]
-    then
-       locale=
-    else
-       locale=${locale}/
-    fi
+    if [ "$locale" = "$suffix" ] && locale= || locale=$locale/
     section=${suffix#*.}
     basename=${basename%%.*}
     (


### PR DESCRIPTION
Without locale, change echoing from:

[...]usr/local/man//man1
[...]usr/local/man//man1/pdf2djvu.1

to:

[...]usr/local/man/man1
[...]usr/local/man/man1/pdf2djvu.1

No functional change.