### PR TITLE
Add missing header

### DIFF
--- a/sys-uuid.cc
+++ b/sys-uuid.cc
@@ -68,6 +68,7 @@ void uuid_unparse_lower(uuid_t &uu, char *out)
 
 #include <cassert>
 #include <cerrno>
+#include <cstring>
 #include <cstdint>
 
 #include <uuid.h>


### PR DESCRIPTION
pdf2djvu doesn't build with g++ 8.3 on OpenBSD/sparc64 without this change.

For reference:

```plain
c++ -O2 -pipe -Wall -Wempty-body -Werror=misleading-indentation -Werror=narrowing -Werror=overloaded-virtual -I/usr/local/include -pthread -I/usr/local/include/poppler -I/usr/local/include/GraphicsMagick -I/usr/local/include  -I/usr/local/include -I/usr/X11R6/include   -c -o sys-uuid.o sys-uuid.cc
In file included from /usr/local/include/c++/8.3.0/cassert:44,
                 from sys-uuid.cc:69:
sys-uuid.cc: In function 'void uuid_unparse_lower(uuid_t&, char*)':
sys-uuid.cc:96:12: error: 'strlen' was not declared in this scope
     assert(strlen(s) == 36U);
            ^~~~~~
sys-uuid.cc:96:12: note: 'strlen' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
sys-uuid.cc:71:1:
+#include <cstring>
 #include <cstdint>
sys-uuid.cc:96:12:
     assert(strlen(s) == 36U);
            ^~~~~~
sys-uuid.cc:97:5: error: 'strcpy' was not declared in this scope
     strcpy(out, s);
     ^~~~~~
sys-uuid.cc:97:5: note: 'strcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
gmake: *** [<builtin>: sys-uuid.o] Error 1
*** Error 2 in graphics/pdf2djvu (/usr/ports/infrastructure/mk/bsd.port.mk:2781 '/usr/obj/ports/pdf2djvu-0.9.13/.build_done')
*** Error 1 in graphics/pdf2djvu (/usr/ports/infrastructure/mk/bsd.port.mk:2447 'build')
===> Exiting graphics/pdf2djvu with an error
*** Error 1 in /usr/ports (infrastructure/mk/bsd.port.subdir.mk:137 'build')
```